### PR TITLE
Spell Updates

### DIFF
--- a/BigDebuffs-WotLK
+++ b/BigDebuffs-WotLK
@@ -1,0 +1,1 @@
+D:/Spel/World of Warcraft - WotLK/Interface/AddOns/BigDebuffs-WotLK

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -76,6 +76,7 @@ BigDebuffs.Spells = {
 	["Mind Freeze"] = { type = "interrupts", interruptduration = 3, },  -- Mind Freeze (Death Knight)
 	-- Druid
 	[22842] = { type = "buffs_defensive", },  -- Frenzied Regeneration
+	[17116] = { type = "buffs_defensive", }, -- Nature's Swiftness
 	[61336] = { type = "buffs_defensive", },  -- Survival Instincts
 	[22812] = { type = "buffs_defensive", },  -- Barkskin
 	[29166] = { type = "buffs_offensive", },  -- Innervate
@@ -203,6 +204,7 @@ BigDebuffs.Spells = {
 	[32182] = { type = "buffs_offensive", },  -- Heroism
 	[16191] = { type = "buffs_offensive", }, -- Mana Tide Totem
 	[30823] = { type = "buffs_defensive", }, -- Shamanistic Rage
+	[16188] = { type = "buffs_defensive", }, -- Nature's Swiftness
 	[51514] = { type = "cc", },  -- Hex
 	[39796] = { type = "cc", }, -- Stoneclaw Stun
 	[8178] = { type = "immunities_spells", }, -- Grounding Totem Effect

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -78,7 +78,6 @@ BigDebuffs.Spells = {
 	[61336] = { type = "buffs_defensive", },  -- Survival Instincts
 	[22812] = { type = "buffs_defensive", },  -- Barkskin
 	[29166] = { type = "buffs_offensive", },  -- Innervate
-	[50213] = { type = "buffs_offensive", },  -- Tiger's Fury
 	[50334] = { type = "buffs_offensive", },  -- Berserk
 	[33357] = { type = "buffs_other", },  -- Dash
 	[49802] = { type = "cc" },  -- Maim

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -116,6 +116,9 @@ BigDebuffs.Spells = {
 	[53562] = { type = "cc", }, -- Ravage (Pet)
 	[53543] = { type = "cc", }, -- Snatch (Pet Disarm)
 	[48999] = { type = "roots", }, -- Counterattack
+	[19185] = { type = "roots", }, -- Entrapment
+		[64803] = { type = "roots", },
+		[64804] = { type = "roots", },
 	[53548] = { type = "roots", }, -- Pin (Pet)
 	[4167] = { type = "roots", }, -- Web (Pet)
 	[26090] = { type = "interrupts", interruptduration = 2, }, -- Pummel (Pet)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -64,7 +64,7 @@ local defaults = {
 
 BigDebuffs.Spells = {
 	-- Death Knight
-	[66023] = { type = "buffs_defensive", },  -- Icebound Fortitude
+	[48792] = { type = "buffs_defensive", },  -- Icebound Fortitude
 	[51052] = { type = "buffs_defensive", },  -- Anti-Magic Zone // might not work because spell vs aura
 	[49028] = { type = "buffs_offensive", },  -- Dancing Rune Weapon // might not work - spell id vs aura
 	[49916] = { type = "cc", },  -- Strangulate

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -222,6 +222,9 @@ BigDebuffs.Spells = {
 	[3411] = { type = "buffs_defensive", },  -- Intervene
 	[2565] = { type = "buffs_defensive", }, -- Shield Block
 	[20230] = { type = "buffs_defensive", }, -- Retaliation
+	[60503] = { type = "buffs_offensive", }, -- Taste for Blood
+	[64849] = { type = "buffs_offensive", }, -- Unrelenting Assault (1/2)
+	[65925] = { type = "buffs_offensive", }, -- Unrelenting Assault (2/2)
 	[1719] = { type = "buffs_offensive", },  -- Recklessness
 	[18499] = { type = "buffs_other", },  -- Berserker Rage
 	[676] = { type = "cc", },  -- Disarm

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -117,6 +117,7 @@ BigDebuffs.Spells = {
 	[53359] = { type = "cc", }, -- Chimera Shot - Scorpid (Disarm)
 	[53562] = { type = "cc", }, -- Ravage (Pet)
 	[53543] = { type = "cc", }, -- Snatch (Pet Disarm)
+	[34490] = { type = "cc", }, -- Silencing Shot
 	[48999] = { type = "roots", }, -- Counterattack
 	[19185] = { type = "roots", }, -- Entrapment
 		[64803] = { type = "roots", },

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -147,6 +147,7 @@ BigDebuffs.Spells = {
 	[42917] = { type = "roots", },  -- Frost Nova
 	[2139] = { type = "interrupts", interruptduration = 6, },  -- Counterspell (Mage)
 	-- Paladin
+	[54428] = { type = "buffs_other", }, -- Divine Plea
 	[10278] = { type = "buffs_defensive", },  -- Hand of Protection
 		[5599] = { type = "buffs_defensive", },
 		[1022] = { type = "buffs_defensive", },

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -63,65 +63,55 @@ local defaults = {
 }
 
 BigDebuffs.Spells = {
-	[47585] = { type = "buffs_defensive", },  -- Dispersion
-	[22842] = { type = "buffs_defensive", },  -- Frenzied Regeneration
-	[10278] = { type = "buffs_defensive", },  -- Hand of Protection
-		[5599] = { type = "buffs_defensive", },
-		[1022] = { type = "buffs_defensive", },
-	[20711] = { type = "buffs_defensive", },  -- Spirit of Redemption
-	[61336] = { type = "buffs_defensive", },  -- Survival Instincts
-	[53480] = { type = "buffs_defensive", },  -- Roar of Sacrifice (Hunter Pet Skill)
-	[19263] = { type = "buffs_defensive", },  -- Deterrence
-	[26669] = { type = "buffs_defensive", },  -- Evasion
-	[31852] = { type = "buffs_defensive", },  -- Ardent Defender
-	[22812] = { type = "buffs_defensive", },  -- Barkskin
-	[6346] = { type = "buffs_defensive", },  -- Fear Ward
-	[12975] = { type = "buffs_defensive", },  -- Last Stand
-	[14751] = { type = "buffs_defensive", },  -- Inner Focus
-	[33206] = { type = "buffs_defensive", },  -- Pain Suppression
-	[31821] = { type = "buffs_defensive", },  -- Aura Mastery
+	-- Death Knight
 	[66023] = { type = "buffs_defensive", },  -- Icebound Fortitude
-	[47788] = { type = "buffs_defensive", },  -- Guardian Spirit
-	[55694] = { type = "buffs_defensive", },  -- Enraged Regeneration
-	[64843] = { type = "buffs_defensive", },  -- Divine Hymn
-	[871] = { type = "buffs_defensive", },  -- Shield Wall
-	[43039] = { type = "buffs_defensive", },  -- Ice Barrier
-	[5384] = { type = "buffs_defensive", },  -- Feign Death
-	[498] = { type = "buffs_defensive", },  -- Divine Protection
-	[6940] = { type = "buffs_defensive", },  -- Hand of Sacrifice
-	[1044] = { type = "buffs_defensive", },  -- Hand of Freedom
-	[53271] = { type = "buffs_defensive", },  -- Master's Call
 	[51052] = { type = "buffs_defensive", },  -- Anti-Magic Zone // might not work because spell vs aura
+	[49028] = { type = "buffs_offensive", },  -- Dancing Rune Weapon // might not work - spell id vs aura
+	[49916] = { type = "cc", },  -- Strangulate
+	[47481] = { type = "cc", },  -- Gnaw
+	[49203] = { type = "cc", }, -- Hungering Cold
+	[48707] = { type = "immunities_spells", },  -- Anti-Magic Shell
+	[49039] = { type = "immunities_spells", },  -- Lichborne
+	["Mind Freeze"] = { type = "interrupts", interruptduration = 3, },  -- Mind Freeze (Death Knight)
+	-- Druid
+	[22842] = { type = "buffs_defensive", },  -- Frenzied Regeneration
+	[61336] = { type = "buffs_defensive", },  -- Survival Instincts
+	[22812] = { type = "buffs_defensive", },  -- Barkskin
 	[29166] = { type = "buffs_offensive", },  -- Innervate
 	[50213] = { type = "buffs_offensive", },  -- Tiger's Fury
-	[49028] = { type = "buffs_offensive", },  -- Dancing Rune Weapon // might not work - spell id vs aura
+	[50334] = { type = "buffs_offensive", },  -- Berserk
+	[33357] = { type = "buffs_other", },  -- Dash
+	[49802] = { type = "cc" },  -- Maim
+	[8983] = { type = "cc", },  -- Bash
+	[18658] = {type = "cc"}, -- Hibernate
+		[2637] = {type = "cc"},
+		[18657] = {type = "cc"},
+	[49803] = { type = "cc", },  -- Pounce
+	[33786] = { type = "cc" },  -- Cyclone
+	[69369] = { type = "buffs_offensive", }, -- Predator's Swiftness
+	[45334] = { type = "roots", },  -- Feral Charge Effect
+	[53308] = { type = "roots", },  -- Entangling Roots
+	["Feral Charge - Bear"] = { type = "interrupts", interruptduration = 4, },  -- Feral Charge - Bear (Druid)
+	-- Hunter
+	[53480] = { type = "buffs_defensive", },  -- Roar of Sacrifice (Hunter Pet Skill)
+	[19263] = { type = "buffs_defensive", },  -- Deterrence
+	[5384] = { type = "buffs_defensive", },  -- Feign Death
+	[53271] = { type = "buffs_defensive", },  -- Master's Call
+	[34471] = { type = "buffs_offensive", },  -- The Beast Within
+	[3034] = { type = "buffs_other", },  -- Viper Sting
+	[24394] = { type = "cc", },  -- Intimidation
+		[19577] = { type = "cc", },
+	[49012] = { type = "cc", },  -- Wyvern Sting
+	[19503] = { type = "cc", },  -- Scatter Shot
+	[14309] = { type = "cc", },  -- Freezing Trap
+	-- Mage
+	[43039] = { type = "buffs_defensive", },  -- Ice Barrier
 	[12472] = { type = "buffs_offensive", },  -- Icy Veins
-	[31884] = { type = "buffs_offensive", },  -- Avenging Wrath
-	[13750] = { type = "buffs_offensive", },  -- Adrenaline Rush
 	[28682] = { type = "buffs_offensive", },  -- Combustion
 	[12042] = { type = "buffs_offensive", },  -- Arcane Power
-	[64701] = { type = "buffs_offensive", },  -- Elemental Mastery
-	[50334] = { type = "buffs_offensive", },  -- Berserk
-	[1719] = { type = "buffs_offensive", },  -- Recklessness
-	[2825] = { type = "buffs_offensive", },  -- Bloodlust
-		[32182] = { type = "buffs_offensive"},  -- Heroism
-	[51690] = { type = "buffs_offensive", },  -- Killing Spree
-	[10060] = { type = "buffs_offensive", },  -- Power Infusion
 	[12043] = { type = "buffs_offensive", },  -- Presence of Mind
 	[12051] = { type = "buffs_offensive", },  -- Evocation
 	[66] = { type = "buffs_offensive", },  -- Invisibility
-	[34471] = { type = "buffs_offensive", },  -- The Beast Within
-	[57073] = { type = "buffs_other", },  -- Drink
-	[33357] = { type = "buffs_other", },  -- Dash
-	[11305] = { type = "buffs_other", },  -- Sprint
-	[3034] = { type = "buffs_other", },  -- Viper Sting
-	[18708] = { type = "buffs_other", },  -- Fel Domination
-	[18499] = { type = "buffs_other", },  -- Berserker Rage
-	[47847] = { type = "cc", },  -- Shadowfury
-	[1776] = { type = "cc", },  -- Gouge
-	[676] = { type = "cc", },  -- Disarm
-	[51722] = {type = "cc", }, -- Dismantle
-	[51514] = { type = "cc", },  -- Hex
 	[118] = { type = "cc", },  -- Polymorph
 		[12826] = { type = "cc", },
 		[71319] = { type = "cc", },
@@ -129,72 +119,95 @@ BigDebuffs.Spells = {
 		[28272] = { type = "cc", },
 		[61305] = { type = "cc", },
 		[61721] = { type = "cc", },
-	[24394] = { type = "cc", },  -- Intimidation
-		[19577] = { type = "cc", },
-	[49802] = { type = "cc" },  -- Maim
-	[2094] = { type = "cc", },  -- Blind
-	[8983] = { type = "cc", },  -- Bash
-	[8643] = { type = "cc", },  -- Kidney Shot
-	[51724] = { type = "cc", },  -- Sap
-	[18658] = {type = "cc"}, -- Hibernate
-		[2637] = {type = "cc"},
-		[18657] = {type = "cc"},
-	[49012] = { type = "cc", },  -- Wyvern Sting
-	[49916] = { type = "cc", },  -- Strangulate 
-	[1330] = { type = "cc", },  -- Garrote - Silence
-	[31117] = { type = "cc", },  -- Unstable Affliction (Silence)
-	[34490] = { type = "cc", },
-	[20066] = { type = "cc", },  -- Repentance
-	[55918] = { type = "cc", },  -- Shockwave
-		[46968] = { type = "cc", },
-	[47481] = { type = "cc", },  -- Gnaw
-	[27610] = { type = "cc", },  -- Psychic Scream
-		[10890] = { type = "cc", },
-	[19503] = { type = "cc", },  -- Scatter Shot
-	[18647] = { type = "cc", },  -- Banish
-	[14309] = { type = "cc", },  -- Freezing Trap
-	[15487] = { type = "cc", },  -- Silence
-	[47860] = { type = "cc", },  -- Death Coil
-	[10308] = { type = "cc", },  -- Hammer of Justice
-	[20549] = { type = "cc", },  -- War Stomp
-	[5246] = { type = "cc", },  -- Intimidating Shout
-	[605] = { type = "cc", },  -- Mind Control
-	[6358] = { type = "cc", },  -- Seduction
-	[6215] = { type = "cc", },  -- Fear
-	[17928] = { type = "cc", },  -- Howl of Terror
-	[1833] = { type = "cc", },  -- Cheap Shot
-	[49803] = { type = "cc", },  -- Pounce
-	[33786] = { type = "cc" },  -- Cyclone
-	[69369] = { type = "buffs_offensive", }, -- Predator's Swiftness ---- problem here
 	[42950] = { type = "cc", },  -- Dragon's Breath
-	[10955] = { type = "cc", },  -- Shackle Undead
-	[7922] = { type = "cc", }, -- Charge
-		[65929] = { type = "cc", },
-	[25274] = { type = "cc", }, -- Intercept
-	[49203] = { type = "cc", }, -- Hungering Cold
 	[45438] = { type = "immunities", },  -- Ice Block
-	[65947] = { type = "immunities", },  -- Bladestorm
-		[63784] = { type = "immunities", },
-		[46924] = { type = "immunities", },
-	[63148] = { type = "immunities", },  -- Divine Shield
-	[23920] = { type = "immunities_spells", },  -- Spell Reflection
-		[59725] = { type = "immunities_spells", },
-	[48707] = { type = "immunities_spells", },  -- Anti-Magic Shell
-	[31224] = { type = "immunities_spells", },  -- Cloak of Shadows
-	[49039] = { type = "immunities_spells", },  -- Lichborne
-	[45334] = { type = "roots", },  -- Feral Charge Effect
 	[12494] = { type = "roots", },  -- Frostbite
 	[42917] = { type = "roots", },  -- Frost Nova
 	[44572] = { type = "cc" }, -- Deep Freeze
-	[53308] = { type = "roots", },  -- Entangling Roots
-	[8178] = { type = "immunities_spells", }, -- Grounding Totem Effect
-	["Pummel"] = { type = "interrupts", interruptduration = 4, },  -- Pummel (Warrior)
 	["Counterspell"] = { type = "interrupts", interruptduration = 6, },  -- Counterspell (Mage)
-	["Spell Lock"] = { type = "interrupts", interruptduration = 5, },  -- Spell Lock (Warlock)
-	["Mind Freeze"] = { type = "interrupts", interruptduration = 3, },  -- Mind Freeze (Death Knight)
-	["Feral Charge - Bear"] = { type = "interrupts", interruptduration = 4, },  -- Feral Charge - Bear (Druid)
-	["Wind Shear"] = { type = "interrupts", interruptduration = 3, },  -- Wind Shear (Shaman)
+	-- Paladin
+	[10278] = { type = "buffs_defensive", },  -- Hand of Protection
+		[5599] = { type = "buffs_defensive", },
+		[1022] = { type = "buffs_defensive", },
+	[31852] = { type = "buffs_defensive", },  -- Ardent Defender
+	[31821] = { type = "buffs_defensive", },  -- Aura Mastery
+	[498] = { type = "buffs_defensive", },  -- Divine Protection
+	[6940] = { type = "buffs_defensive", },  -- Hand of Sacrifice
+	[1044] = { type = "buffs_defensive", },  -- Hand of Freedom
+	[31884] = { type = "buffs_offensive", },  -- Avenging Wrath
+	[20066] = { type = "cc", },  -- Repentance
+	[10308] = { type = "cc", },  -- Hammer of Justice
+	[63148] = { type = "immunities", },  -- Divine Shield
+	-- Priest
+	[47585] = { type = "buffs_defensive", },  -- Dispersion
+	[20711] = { type = "buffs_defensive", },  -- Spirit of Redemption
+	[47788] = { type = "buffs_defensive", },  -- Guardian Spirit
+	[6346] = { type = "buffs_other", },  -- Fear Ward
+	[14751] = { type = "buffs_defensive", },  -- Inner Focus
+	[33206] = { type = "buffs_defensive", },  -- Pain Suppression
+	[64843] = { type = "buffs_defensive", },  -- Divine Hymn
+	[10060] = { type = "buffs_offensive", },  -- Power Infusion
+	[27610] = { type = "cc", },  -- Psychic Scream
+		[10890] = { type = "cc", },
+	[15487] = { type = "cc", },  -- Silence
+	[605] = { type = "cc", },  -- Mind Control
+	[10955] = { type = "cc", },  -- Shackle Undead
+	-- Rogue
+	[51713] = { type = "buffs_offensive", }, -- Shadow Dance
+	[26669] = { type = "buffs_defensive", },  -- Evasion
+	[13750] = { type = "buffs_offensive", },  -- Adrenaline Rush
+	[51690] = { type = "buffs_offensive", },  -- Killing Spree
+	[11305] = { type = "buffs_other", },  -- Sprint
+	[1776] = { type = "cc", },  -- Gouge
+	[51722] = {type = "cc", }, -- Dismantle
+	[2094] = { type = "cc", },  -- Blind
+	[8643] = { type = "cc", },  -- Kidney Shot
+	[51724] = { type = "cc", },  -- Sap
+	[1330] = { type = "cc", },  -- Garrote - Silence
+	[1833] = { type = "cc", },  -- Cheap Shot
+	[31224] = { type = "immunities_spells", },  -- Cloak of Shadows
 	["Kick"] = { type = "interrupts", interruptduration = 5, },  -- Kick (Rogue)
+	-- Shaman
+	[64701] = { type = "buffs_offensive", },  -- Elemental Mastery
+	[2825] = { type = "buffs_offensive", },  -- Bloodlust
+	[32182] = { type = "buffs_offensive"},  -- Heroism
+	[51514] = { type = "cc", },  -- Hex
+	[8178] = { type = "immunities_spells", }, -- Grounding Totem Effect
+	["Wind Shear"] = { type = "interrupts", interruptduration = 3, },  -- Wind Shear (Shaman)
+	-- Warlock
+	[18708] = { type = "buffs_other", },  -- Fel Domination
+	[47847] = { type = "cc", },  -- Shadowfury
+	[31117] = { type = "cc", },  -- Unstable Affliction (Silence)
+		[34490] = { type = "cc", },
+	[18647] = { type = "cc", },  -- Banish
+	[47860] = { type = "cc", },  -- Death Coil
+	[6358] = { type = "cc", },  -- Seduction
+	[6215] = { type = "cc", },  -- Fear
+	[17928] = { type = "cc", },  -- Howl of Terror
+	["Spell Lock"] = { type = "interrupts", interruptduration = 5, },  -- Spell Lock (Warlock)
+	-- Warrior
+	[12975] = { type = "buffs_defensive", },  -- Last Stand
+	[55694] = { type = "buffs_defensive", },  -- Enraged Regeneration
+	[871] = { type = "buffs_defensive", },  -- Shield Wall
+	[3411] = { type = "buffs_offensive", },  -- Intervene
+	[1719] = { type = "buffs_offensive", },  -- Recklessness
+	[18499] = { type = "buffs_other", },  -- Berserker Rage
+	[676] = { type = "cc", },  -- Disarm
+	[55918] = { type = "cc", },  -- Shockwave
+		[46968] = { type = "cc", },
+	[5246] = { type = "cc", },  -- Intimidating Shout
+	[7922] = { type = "cc", }, -- Charge
+		[65929] = { type = "cc", },
+	[25274] = { type = "cc", }, -- Intercept
+	[65947] = { type = "immunities", },  -- Bladestorm
+		[63784] = { type = "immunities", },
+		[46924] = { type = "immunities", },
+	[23920] = { type = "immunities_spells", },  -- Spell Reflection
+		[59725] = { type = "immunities_spells", },
+	["Pummel"] = { type = "interrupts", interruptduration = 4, },  -- Pummel (Warrior)
+	-- Misc
+	[57073] = { type = "buffs_other", },  -- Drink
+	[20549] = { type = "cc", },  -- War Stomp
 }
 
 local units = {

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -126,7 +126,7 @@ BigDebuffs.Spells = {
 	[4167] = { type = "roots", }, -- Web (Pet)
 	[26090] = { type = "interrupts", interruptduration = 2, }, -- Pummel (Pet)
 	-- Mage
-	[43039] = { type = "buffs_defensive", },  -- Ice Barrier
+	[43039] = { type = "buffs_other", },  -- Ice Barrier
 	[12472] = { type = "buffs_offensive", },  -- Icy Veins
 	[28682] = { type = "buffs_offensive", },  -- Combustion
 	[12042] = { type = "buffs_offensive", },  -- Arcane Power
@@ -151,6 +151,7 @@ BigDebuffs.Spells = {
 	[2139] = { type = "interrupts", interruptduration = 6, },  -- Counterspell (Mage)
 	-- Paladin
 	[54428] = { type = "buffs_other", }, -- Divine Plea
+	[58597] = { type = "buffs_other", }, -- Sacred Shield Proc
 	[10278] = { type = "buffs_defensive", },  -- Hand of Protection
 		[5599] = { type = "buffs_defensive", },
 		[1022] = { type = "buffs_defensive", },
@@ -178,6 +179,7 @@ BigDebuffs.Spells = {
 	[64901] = { type = "buffs_defensive", }, -- Hymn of Hope
 	[10060] = { type = "buffs_offensive", },  -- Power Infusion
 	[6346] = { type = "buffs_other", },  -- Fear Ward
+	[48066] = { type = "buffs_other", }, -- Power Word: Shield
 	[64044] = { type = "cc", }, -- Psychic Horror (Horrify)
 	[64058] = { type = "cc", }, -- Psychic Horror (Disarm)
 	[10890] = { type = "cc", },  -- Psychic Scream
@@ -219,6 +221,7 @@ BigDebuffs.Spells = {
 	-- Warlock
 	[47241] = { type = "buffs_offensive", }, -- Metamorphosis
 	[18708] = { type = "buffs_other", },  -- Fel Domination
+	[47986] = { type = "buffs_other", }, -- Sacrifice
 	[60995] = { type = "cc", }, -- Demon Charge (Metamorphosis)
 	[47847] = { type = "cc", },  -- Shadowfury
 	[31117] = { type = "cc", },  -- Unstable Affliction (Silence)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -80,6 +80,7 @@ BigDebuffs.Spells = {
 	[29166] = { type = "buffs_offensive", },  -- Innervate
 	[50334] = { type = "buffs_offensive", },  -- Berserk
 	[69369] = { type = "buffs_offensive", }, -- Predator's Swiftness
+	[53201] = { type = "buffs_offensive", }, -- Starfall
 	[33357] = { type = "buffs_other", },  -- Dash
 	[49802] = { type = "cc" },  -- Maim
 	[8983] = { type = "cc", },  -- Bash

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -229,6 +229,7 @@ BigDebuffs.Spells = {
 	[12292] = { type = "buffs_offensive", }, -- Death Wish
 	[18499] = { type = "buffs_other", },  -- Berserker Rage
 	[12809] = { type = "cc", }, -- Concussion Blow
+	[12798] = { type = "cc", }, -- Revenge Stun
 	[676] = { type = "cc", },  -- Disarm
 	[55918] = { type = "cc", },  -- Shockwave
 		[46968] = { type = "cc", },

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -109,6 +109,7 @@ BigDebuffs.Spells = {
 	[53562] = { type = "cc", }, -- Ravage (Pet)
 	[53543] = { type = "cc", }, -- Snatch (Pet Disarm)
 	[53548] = { type = "roots", }, -- Pin (Pet)
+	[4167] = { type = "roots", }, -- Web (Pet)
 	-- Mage
 	[43039] = { type = "buffs_defensive", },  -- Ice Barrier
 	[12472] = { type = "buffs_offensive", },  -- Icy Veins

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -163,6 +163,7 @@ BigDebuffs.Spells = {
 	[63529] = { type = "cc", }, -- Silenced - Shield of the Templar
 	[10326] = { type = "cc", }, -- Turn Evil
 	[48817] = { type = "cc", }, -- Holy Wrath
+	[20170] = { type = "cc", }, -- Seal of Justice Stun
 	[642] = { type = "immunities", },  -- Divine Shield
 	-- Priest
 	[47585] = { type = "buffs_defensive", },  -- Dispersion

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -98,6 +98,7 @@ BigDebuffs.Spells = {
 	[5384] = { type = "buffs_defensive", },  -- Feign Death
 	[53271] = { type = "buffs_defensive", },  -- Master's Call
 	[53476] = { type = "buffs_defensive", }, -- Intervene (Pet)
+	[1742] = { type = "buffs_defensive", }, -- Cower (Pet)
 	[34471] = { type = "buffs_offensive", },  -- The Beast Within
 	[3034] = { type = "buffs_other", },  -- Viper Sting
 	[24394] = { type = "cc", },  -- Intimidation

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -210,7 +210,7 @@ BigDebuffs.Spells = {
 		[59725] = { type = "immunities_spells", },
 	["Pummel"] = { type = "interrupts", interruptduration = 4, },  -- Pummel (Warrior)
 	-- Misc
-	[57073] = { type = "buffs_other", },  -- Drink
+	[43183] = { type = "buffs_other", },  -- Drink
 	[20549] = { type = "cc", },  -- War Stomp
 }
 

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -209,6 +209,7 @@ BigDebuffs.Spells = {
 	[6215] = { type = "cc", },  -- Fear
 	[17928] = { type = "cc", },  -- Howl of Terror
 	[24259] = { type = "cc", }, -- Spell Lock (Silence)
+	[47995] = { type = "cc", }, -- Intercept (Felguard)
 	[19647] = { type = "interrupts", interruptduration = 6, },  -- Spell Lock (Interrupt)
 	-- Warrior
 	[12975] = { type = "buffs_defensive", },  -- Last Stand

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -125,10 +125,11 @@ BigDebuffs.Spells = {
 	[42950] = { type = "cc", },  -- Dragon's Breath
 	[44572] = { type = "cc", }, -- Deep Freeze
 	[12355] = { type = "cc", }, -- Impact
+	[55021] = { type = "cc", }, -- Improved Counterspell
 	[45438] = { type = "immunities", },  -- Ice Block
 	[12494] = { type = "roots", },  -- Frostbite
 	[42917] = { type = "roots", },  -- Frost Nova
-	["Counterspell"] = { type = "interrupts", interruptduration = 6, },  -- Counterspell (Mage)
+	[2139] = { type = "interrupts", interruptduration = 6, },  -- Counterspell (Mage)
 	-- Paladin
 	[10278] = { type = "buffs_defensive", },  -- Hand of Protection
 		[5599] = { type = "buffs_defensive", },

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -250,7 +250,8 @@ BigDebuffs.Spells = {
 	[12798] = { type = "cc", }, -- Revenge Stun
 	[676] = { type = "cc", },  -- Disarm
 	[46968] = { type = "cc", },  -- Shockwave
-	[5246] = { type = "cc", },  -- Intimidating Shout
+	[5246] = { type = "cc", },  -- Intimidating Shout (Non - Target)
+	[20511] = { type = "cc", }, -- Intimidating Shout (Target)
 	[7922] = { type = "cc", }, -- Charge
 	[20253] = { type = "cc", }, -- Intercept
 	[18498] = { type = "cc", }, -- Silenced - Gag Order

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -230,6 +230,9 @@ BigDebuffs.Spells = {
 	-- Misc
 	[43183] = { type = "buffs_other", },  -- Drink
 	[20549] = { type = "cc", },  -- War Stomp
+	[28730] = { type = "cc", }, -- Arcane Torrent (Mana)
+	[25046] = { type = "cc", }, -- Arcane Torrent (Energy)
+	[50613] = { type = "cc", }, -- Arcane Torrent (Runic Power)
 }
 
 local units = {

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -83,6 +83,7 @@ BigDebuffs.Spells = {
 	[50334] = { type = "buffs_offensive", },  -- Berserk
 	[69369] = { type = "buffs_offensive", }, -- Predator's Swiftness
 	[53201] = { type = "buffs_offensive", }, -- Starfall
+	[53312] = { type = "buffs_other", }, -- Nature's Grasp
 	[33357] = { type = "buffs_other", },  -- Dash
 	[49802] = { type = "cc" },  -- Maim
 	[8983] = { type = "cc", },  -- Bash
@@ -106,8 +107,8 @@ BigDebuffs.Spells = {
 	[19263] = { type = "immunities", },  -- Deterrence
 	[19574] = { type = "immunities", }, -- Bestial Wrath (Pet)
 	[3034] = { type = "buffs_other", },  -- Viper Sting
-	[24394] = { type = "cc", },  -- Intimidation
-		[19577] = { type = "cc", },
+	[24394] = { type = "cc", },  -- Intimidation (Stun)
+		[19577] = { type = "buffs_offensive", }, -- Intimidation (Pet Buff)
 	[49012] = { type = "cc", },  -- Wyvern Sting
 	[19503] = { type = "cc", },  -- Scatter Shot
 	[14309] = { type = "cc", },  -- Freezing Trap
@@ -178,8 +179,7 @@ BigDebuffs.Spells = {
 	[6346] = { type = "buffs_other", },  -- Fear Ward
 	[64044] = { type = "cc", }, -- Psychic Horror (Horrify)
 	[64058] = { type = "cc", }, -- Psychic Horror (Disarm)
-	[27610] = { type = "cc", },  -- Psychic Scream
-		[10890] = { type = "cc", },
+	[10890] = { type = "cc", },  -- Psychic Scream
 	[15487] = { type = "cc", },  -- Silence
 	[605] = { type = "cc", },  -- Mind Control
 	[10955] = { type = "cc", },  -- Shackle Undead
@@ -220,7 +220,6 @@ BigDebuffs.Spells = {
 	[60995] = { type = "cc", }, -- Demon Charge (Metamorphosis)
 	[47847] = { type = "cc", },  -- Shadowfury
 	[31117] = { type = "cc", },  -- Unstable Affliction (Silence)
-		[34490] = { type = "cc", },
 	[18647] = { type = "cc", },  -- Banish
 	[47860] = { type = "cc", },  -- Death Coil
 	[6358] = { type = "cc", },  -- Seduction
@@ -245,17 +244,12 @@ BigDebuffs.Spells = {
 	[12809] = { type = "cc", }, -- Concussion Blow
 	[12798] = { type = "cc", }, -- Revenge Stun
 	[676] = { type = "cc", },  -- Disarm
-	[55918] = { type = "cc", },  -- Shockwave
-		[46968] = { type = "cc", },
+	[46968] = { type = "cc", },  -- Shockwave
 	[5246] = { type = "cc", },  -- Intimidating Shout
 	[7922] = { type = "cc", }, -- Charge
-		[65929] = { type = "cc", },
 	[30197] = { type = "cc", }, -- Intercept
-	[65947] = { type = "immunities", },  -- Bladestorm
-		[63784] = { type = "immunities", },
-		[46924] = { type = "immunities", },
+	[46924] = { type = "immunities", },  -- Bladestorm
 	[23920] = { type = "immunities_spells", },  -- Spell Reflection
-		[59725] = { type = "immunities_spells", },
 	[6552] = { type = "interrupts", interruptduration = 4, },  -- Pummel
 	[72] = { type = "interrupts", interruptduration = 6, }, -- Shield Bash
 	-- Misc

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -175,6 +175,7 @@ BigDebuffs.Spells = {
 	[51514] = { type = "cc", },  -- Hex
 	[8178] = { type = "immunities_spells", }, -- Grounding Totem Effect
 	[63685] = { type = "roots", }, -- Freeze (Enhancement)
+	[64695] = { type = "roots", }, -- Earthgrab (Elemental)
 	[8145] = { type = "buffs_other", }, -- Tremor Totem
 	["Wind Shear"] = { type = "interrupts", interruptduration = 3, },  -- Wind Shear (Shaman)
 	-- Warlock

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -225,7 +225,8 @@ BigDebuffs.Spells = {
 		[46924] = { type = "immunities", },
 	[23920] = { type = "immunities_spells", },  -- Spell Reflection
 		[59725] = { type = "immunities_spells", },
-	["Pummel"] = { type = "interrupts", interruptduration = 4, },  -- Pummel (Warrior)
+	[6552] = { type = "interrupts", interruptduration = 4, },  -- Pummel
+	[72] = { type = "interrupts", interruptduration = 6, }, -- Shield Bash
 	-- Misc
 	[43183] = { type = "buffs_other", },  -- Drink
 	[20549] = { type = "cc", },  -- War Stomp

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -253,6 +253,7 @@ BigDebuffs.Spells = {
 	[5246] = { type = "cc", },  -- Intimidating Shout
 	[7922] = { type = "cc", }, -- Charge
 	[20253] = { type = "cc", }, -- Intercept
+	[18498] = { type = "cc", }, -- Silenced - Gag Order
 	[46924] = { type = "immunities", },  -- Bladestorm
 	[23920] = { type = "immunities_spells", },  -- Spell Reflection
 	[6552] = { type = "interrupts", interruptduration = 4, },  -- Pummel

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -95,13 +95,14 @@ BigDebuffs.Spells = {
 	["Feral Charge - Bear"] = { type = "interrupts", interruptduration = 4, },  -- Feral Charge - Bear (Druid)
 	-- Hunter
 	[53480] = { type = "buffs_defensive", },  -- Roar of Sacrifice (Hunter Pet Skill)
-	[19263] = { type = "buffs_defensive", },  -- Deterrence
 	[5384] = { type = "buffs_defensive", },  -- Feign Death
 	[53271] = { type = "buffs_defensive", },  -- Master's Call
 	[53476] = { type = "buffs_defensive", }, -- Intervene (Pet)
 	[1742] = { type = "buffs_defensive", }, -- Cower (Pet)
 	[26064] = { type = "buffs_defensive", }, -- Shell Shield (Pet)
-	[34471] = { type = "buffs_offensive", },  -- The Beast Within
+	[34471] = { type = "immunities", },  -- The Beast Within
+	[19263] = { type = "immunities", },  -- Deterrence
+	[19574] = { type = "immunities", }, -- Bestial Wrath (Pet)
 	[3034] = { type = "buffs_other", },  -- Viper Sting
 	[24394] = { type = "cc", },  -- Intimidation
 		[19577] = { type = "cc", },

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -124,7 +124,7 @@ BigDebuffs.Spells = {
 		[61721] = { type = "cc", },
 	[42950] = { type = "cc", },  -- Dragon's Breath
 	[44572] = { type = "cc", }, -- Deep Freeze
-	[64343] = { type = "cc", }, -- Impact
+	[12355] = { type = "cc", }, -- Impact
 	[45438] = { type = "immunities", },  -- Ice Block
 	[12494] = { type = "roots", },  -- Frostbite
 	[42917] = { type = "roots", },  -- Frost Nova

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -115,6 +115,7 @@ BigDebuffs.Spells = {
 	[53359] = { type = "cc", }, -- Chimera Shot - Scorpid (Disarm)
 	[53562] = { type = "cc", }, -- Ravage (Pet)
 	[53543] = { type = "cc", }, -- Snatch (Pet Disarm)
+	[48999] = { type = "roots", }, -- Counterattack
 	[53548] = { type = "roots", }, -- Pin (Pet)
 	[4167] = { type = "roots", }, -- Web (Pet)
 	[26090] = { type = "interrupts", interruptduration = 2, }, -- Pummel (Pet)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -772,6 +772,9 @@ function BigDebuffs:UNIT_AURA(event, unit)
 		if duration > 1 then
 			frame.cooldown:SetCooldown(expires - duration, duration)
 			frame.cooldownContainer:Show()
+		else 
+			frame.cooldown:SetCooldown(0, 0)
+			frame.cooldownContainer:Hide()
 		end
 
 		frame:Show()

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -226,6 +226,7 @@ BigDebuffs.Spells = {
 	[64849] = { type = "buffs_offensive", }, -- Unrelenting Assault (1/2)
 	[65925] = { type = "buffs_offensive", }, -- Unrelenting Assault (2/2)
 	[1719] = { type = "buffs_offensive", },  -- Recklessness
+	[12292] = { type = "buffs_offensive", }, -- Death Wish
 	[18499] = { type = "buffs_other", },  -- Berserker Rage
 	[676] = { type = "cc", },  -- Disarm
 	[55918] = { type = "cc", },  -- Shockwave

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -87,7 +87,7 @@ BigDebuffs.Spells = {
 		[2637] = {type = "cc"},
 		[18657] = {type = "cc"},
 	[49803] = { type = "cc", },  -- Pounce
-	[33786] = { type = "cc" },  -- Cyclone
+	[33786] = { type = "immunities" },  -- Cyclone
 	[45334] = { type = "roots", },  -- Feral Charge Effect
 	[53308] = { type = "roots", },  -- Entangling Roots
 	["Feral Charge - Bear"] = { type = "interrupts", interruptduration = 4, },  -- Feral Charge - Bear (Druid)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -79,6 +79,7 @@ BigDebuffs.Spells = {
 	[22812] = { type = "buffs_defensive", },  -- Barkskin
 	[29166] = { type = "buffs_offensive", },  -- Innervate
 	[50334] = { type = "buffs_offensive", },  -- Berserk
+	[69369] = { type = "buffs_offensive", }, -- Predator's Swiftness
 	[33357] = { type = "buffs_other", },  -- Dash
 	[49802] = { type = "cc" },  -- Maim
 	[8983] = { type = "cc", },  -- Bash
@@ -87,7 +88,6 @@ BigDebuffs.Spells = {
 		[18657] = {type = "cc"},
 	[49803] = { type = "cc", },  -- Pounce
 	[33786] = { type = "cc" },  -- Cyclone
-	[69369] = { type = "buffs_offensive", }, -- Predator's Swiftness
 	[45334] = { type = "roots", },  -- Feral Charge Effect
 	[53308] = { type = "roots", },  -- Entangling Roots
 	["Feral Charge - Bear"] = { type = "interrupts", interruptduration = 4, },  -- Feral Charge - Bear (Druid)
@@ -119,10 +119,10 @@ BigDebuffs.Spells = {
 		[61305] = { type = "cc", },
 		[61721] = { type = "cc", },
 	[42950] = { type = "cc", },  -- Dragon's Breath
+	[44572] = { type = "cc" }, -- Deep Freeze
 	[45438] = { type = "immunities", },  -- Ice Block
 	[12494] = { type = "roots", },  -- Frostbite
 	[42917] = { type = "roots", },  -- Frost Nova
-	[44572] = { type = "cc" }, -- Deep Freeze
 	["Counterspell"] = { type = "interrupts", interruptduration = 6, },  -- Counterspell (Mage)
 	-- Paladin
 	[10278] = { type = "buffs_defensive", },  -- Hand of Protection
@@ -141,11 +141,11 @@ BigDebuffs.Spells = {
 	[47585] = { type = "buffs_defensive", },  -- Dispersion
 	[20711] = { type = "buffs_defensive", },  -- Spirit of Redemption
 	[47788] = { type = "buffs_defensive", },  -- Guardian Spirit
-	[6346] = { type = "buffs_other", },  -- Fear Ward
 	[14751] = { type = "buffs_defensive", },  -- Inner Focus
 	[33206] = { type = "buffs_defensive", },  -- Pain Suppression
 	[64843] = { type = "buffs_defensive", },  -- Divine Hymn
 	[10060] = { type = "buffs_offensive", },  -- Power Infusion
+	[6346] = { type = "buffs_other", },  -- Fear Ward
 	[27610] = { type = "cc", },  -- Psychic Scream
 		[10890] = { type = "cc", },
 	[15487] = { type = "cc", },  -- Silence
@@ -153,10 +153,10 @@ BigDebuffs.Spells = {
 	[10955] = { type = "cc", },  -- Shackle Undead
 	-- Rogue
 	[51713] = { type = "buffs_offensive", }, -- Shadow Dance
-	[26669] = { type = "buffs_defensive", },  -- Evasion
 	[13750] = { type = "buffs_offensive", },  -- Adrenaline Rush
 	[51690] = { type = "buffs_offensive", },  -- Killing Spree
 	[11305] = { type = "buffs_other", },  -- Sprint
+	[26669] = { type = "buffs_defensive", },  -- Evasion
 	[1776] = { type = "cc", },  -- Gouge
 	[51722] = {type = "cc", }, -- Dismantle
 	[2094] = { type = "cc", },  -- Blind

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -186,7 +186,7 @@ BigDebuffs.Spells = {
 	[63685] = { type = "roots", }, -- Freeze (Enhancement)
 	[64695] = { type = "roots", }, -- Earthgrab (Elemental)
 	[8145] = { type = "buffs_other", }, -- Tremor Totem
-	["Wind Shear"] = { type = "interrupts", interruptduration = 3, },  -- Wind Shear (Shaman)
+	["Wind Shear"] = { type = "interrupts", interruptduration = 2, },  -- Wind Shear (Shaman)
 	-- Warlock
 	[18708] = { type = "buffs_other", },  -- Fel Domination
 	[47847] = { type = "cc", },  -- Shadowfury

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -208,12 +208,13 @@ BigDebuffs.Spells = {
 	[16191] = { type = "buffs_offensive", }, -- Mana Tide Totem
 	[30823] = { type = "buffs_defensive", }, -- Shamanistic Rage
 	[16188] = { type = "buffs_defensive", }, -- Nature's Swiftness
+	[58861] = { type = "cc", }, -- Bash (Spirit Wolf)
 	[51514] = { type = "cc", },  -- Hex
 	[39796] = { type = "cc", }, -- Stoneclaw Stun
 	[8178] = { type = "immunities_spells", }, -- Grounding Totem Effect
 	[63685] = { type = "roots", }, -- Freeze (Enhancement)
 	[64695] = { type = "roots", }, -- Earthgrab (Elemental)
-	[8145] = { type = "buffs_other", }, -- Tremor Totem
+	[58875] = { type = "buffs_other", }, -- Spirit Walk (Spirit Wolf)
 	[57994] = { type = "interrupts", interruptduration = 2, },  -- Wind Shear
 	-- Warlock
 	[47241] = { type = "buffs_offensive", }, -- Metamorphosis
@@ -248,7 +249,7 @@ BigDebuffs.Spells = {
 	[46968] = { type = "cc", },  -- Shockwave
 	[5246] = { type = "cc", },  -- Intimidating Shout
 	[7922] = { type = "cc", }, -- Charge
-	[30197] = { type = "cc", }, -- Intercept
+	[20253] = { type = "cc", }, -- Intercept
 	[46924] = { type = "immunities", },  -- Bladestorm
 	[23920] = { type = "immunities_spells", },  -- Spell Reflection
 	[6552] = { type = "interrupts", interruptduration = 4, },  -- Pummel

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -142,6 +142,8 @@ BigDebuffs.Spells = {
 	[20066] = { type = "cc", },  -- Repentance
 	[10308] = { type = "cc", },  -- Hammer of Justice
 	[63529] = { type = "cc", }, -- Silenced - Shield of the Templar
+	[10326] = { type = "cc", }, -- Turn Evil
+	[48817] = { type = "cc", }, -- Holy Wrath
 	[642] = { type = "immunities", },  -- Divine Shield
 	-- Priest
 	[47585] = { type = "buffs_defensive", },  -- Dispersion

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -208,7 +208,7 @@ BigDebuffs.Spells = {
 	[5246] = { type = "cc", },  -- Intimidating Shout
 	[7922] = { type = "cc", }, -- Charge
 		[65929] = { type = "cc", },
-	[25274] = { type = "cc", }, -- Intercept
+	[30197] = { type = "cc", }, -- Intercept
 	[65947] = { type = "immunities", },  -- Bladestorm
 		[63784] = { type = "immunities", },
 		[46924] = { type = "immunities", },

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -94,6 +94,7 @@ BigDebuffs.Spells = {
 	[53308] = { type = "roots", },  -- Entangling Roots
 	["Feral Charge - Bear"] = { type = "interrupts", interruptduration = 4, },  -- Feral Charge - Bear (Druid)
 	-- Hunter
+	[3045] = { type = "buffs_offensive", }, -- Rapid Fire
 	[53480] = { type = "buffs_defensive", },  -- Roar of Sacrifice (Hunter Pet Skill)
 	[5384] = { type = "buffs_defensive", },  -- Feign Death
 	[53271] = { type = "buffs_defensive", },  -- Master's Call

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -110,6 +110,7 @@ BigDebuffs.Spells = {
 	[19503] = { type = "cc", },  -- Scatter Shot
 	[14309] = { type = "cc", },  -- Freezing Trap
 	[60210] = { type = "cc", }, -- Freezing Arrow Effect
+	[14327] = { type = "cc", }, -- Scare Beast
 	[53359] = { type = "cc", }, -- Chimera Shot - Scorpid (Disarm)
 	[53562] = { type = "cc", }, -- Ravage (Pet)
 	[53543] = { type = "cc", }, -- Snatch (Pet Disarm)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -259,7 +259,8 @@ BigDebuffs.Spells = {
 	[6552] = { type = "interrupts", interruptduration = 4, },  -- Pummel
 	[72] = { type = "interrupts", interruptduration = 6, }, -- Shield Bash
 	-- Misc
-	[43183] = { type = "buffs_other", },  -- Drink
+	[43183] = { type = "buffs_other", },  -- Drink (Arena/Lvl 80 Water)
+		[57073] = { type = "buffs_other" }, -- (Mage Water)
 	[20549] = { type = "cc", },  -- War Stomp
 	[28730] = { type = "cc", }, -- Arcane Torrent (Mana)
 	[25046] = { type = "cc", }, -- Arcane Torrent (Energy)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -211,6 +211,7 @@ BigDebuffs.Spells = {
 	[55694] = { type = "buffs_defensive", },  -- Enraged Regeneration
 	[871] = { type = "buffs_defensive", },  -- Shield Wall
 	[3411] = { type = "buffs_defensive", },  -- Intervene
+	[2565] = { type = "buffs_defensive", }, -- Shield Block
 	[1719] = { type = "buffs_offensive", },  -- Recklessness
 	[18499] = { type = "buffs_other", },  -- Berserker Rage
 	[676] = { type = "cc", },  -- Disarm

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1,5 +1,7 @@
 
--- BigDebuffs by Jordon (& improved / backported by Konjunktur & Apparent)
+-- BigDebuffs by Jordon 
+-- Backported and general improvements by Konjunktur
+-- Spell list and minor improvements by Apparent
 
 BigDebuffs = LibStub("AceAddon-3.0"):NewAddon("BigDebuffs", "AceEvent-3.0", "AceHook-3.0", "AceTimer-3.0")
 
@@ -637,7 +639,6 @@ end
 function BigDebuffs:COMBAT_LOG_EVENT_UNFILTERED(_, ...)
 	_, subEvent, sourceGUID, _, _, destGUID, destName, _, spellid, name = ...
 
-	-- Setting the "last known" warrior stance for each unit
 	if subEvent == "SPELL_CAST_SUCCESS" and self.Spells[spellid] then
 		if spellid == 2457 or spellid == 2458 or spellid == 71 then
 			unit = self:GetUnitFromGUID(sourceGUID)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -204,7 +204,7 @@ BigDebuffs.Spells = {
 	[31224] = { type = "immunities_spells", },  -- Cloak of Shadows
 	[1766] = { type = "interrupts", interruptduration = 5, },  -- Kick
 	-- Shaman
-	[64701] = { type = "buffs_offensive", },  -- Elemental Mastery
+	[16166] = { type = "buffs_offensive", }, -- Elemental Mastery (Instant Cast)
 	[2825] = { type = "buffs_offensive", },  -- Bloodlust
 	[32182] = { type = "buffs_offensive", },  -- Heroism
 	[16191] = { type = "buffs_offensive", }, -- Mana Tide Totem

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -99,6 +99,7 @@ BigDebuffs.Spells = {
 	[53271] = { type = "buffs_defensive", },  -- Master's Call
 	[53476] = { type = "buffs_defensive", }, -- Intervene (Pet)
 	[1742] = { type = "buffs_defensive", }, -- Cower (Pet)
+	[26064] = { type = "buffs_defensive", }, -- Shell Shield (Pet)
 	[34471] = { type = "buffs_offensive", },  -- The Beast Within
 	[3034] = { type = "buffs_other", },  -- Viper Sting
 	[24394] = { type = "cc", },  -- Intimidation

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -106,6 +106,7 @@ BigDebuffs.Spells = {
 	[19503] = { type = "cc", },  -- Scatter Shot
 	[14309] = { type = "cc", },  -- Freezing Trap
 	[60210] = { type = "cc", }, -- Freezing Arrow Effect
+	[53359] = { type = "cc", }, -- Chimera Shot - Scorpid (Disarm)
 	[53562] = { type = "cc", }, -- Ravage (Pet)
 	[53543] = { type = "cc", }, -- Snatch (Pet Disarm)
 	[53548] = { type = "roots", }, -- Pin (Pet)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -176,6 +176,8 @@ BigDebuffs.Spells = {
 	[64901] = { type = "buffs_defensive", }, -- Hymn of Hope
 	[10060] = { type = "buffs_offensive", },  -- Power Infusion
 	[6346] = { type = "buffs_other", },  -- Fear Ward
+	[64044] = { type = "cc", }, -- Psychic Horror (Horrify)
+	[64058] = { type = "cc", }, -- Psychic Horror (Disarm)
 	[27610] = { type = "cc", },  -- Psychic Scream
 		[10890] = { type = "cc", },
 	[15487] = { type = "cc", },  -- Silence

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -158,6 +158,7 @@ BigDebuffs.Spells = {
 	-- Paladin
 	[54428] = { type = "buffs_other", }, -- Divine Plea
 	[58597] = { type = "buffs_other", }, -- Sacred Shield Proc
+	[59578] = { type = "buffs_other", }, -- The Art of War
 	[10278] = { type = "buffs_defensive", },  -- Hand of Protection
 		[5599] = { type = "buffs_defensive", },
 		[1022] = { type = "buffs_defensive", },

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -104,6 +104,8 @@ BigDebuffs.Spells = {
 	[19503] = { type = "cc", },  -- Scatter Shot
 	[14309] = { type = "cc", },  -- Freezing Trap
 	[60210] = { type = "cc", }, -- Freezing Arrow Effect
+	[53562] = { type = "cc", }, -- Ravage (Pet)
+	[53548] = { type = "roots", }, -- Pin (Pet)
 	-- Mage
 	[43039] = { type = "buffs_defensive", },  -- Ice Barrier
 	[12472] = { type = "buffs_offensive", },  -- Icy Veins

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -141,7 +141,7 @@ BigDebuffs.Spells = {
 	[20066] = { type = "cc", },  -- Repentance
 	[10308] = { type = "cc", },  -- Hammer of Justice
 	[63529] = { type = "cc", }, -- Silenced - Shield of the Templar
-	[63148] = { type = "immunities", },  -- Divine Shield
+	[642] = { type = "immunities", },  -- Divine Shield
 	-- Priest
 	[47585] = { type = "buffs_defensive", },  -- Dispersion
 	[20711] = { type = "buffs_defensive", },  -- Spirit of Redemption

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -201,6 +201,7 @@ BigDebuffs.Spells = {
 	-- Warlock
 	[47241] = { type = "buffs_offensive", }, -- Metamorphosis
 	[18708] = { type = "buffs_other", },  -- Fel Domination
+	[60995] = { type = "cc", }, -- Demon Charge (Metamorphosis)
 	[47847] = { type = "cc", },  -- Shadowfury
 	[31117] = { type = "cc", },  -- Unstable Affliction (Silence)
 		[34490] = { type = "cc", },

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -65,7 +65,7 @@ local defaults = {
 BigDebuffs.Spells = {
 	-- Death Knight
 	[48792] = { type = "buffs_defensive", },  -- Icebound Fortitude
-	[51052] = { type = "buffs_defensive", },  -- Anti-Magic Zone // might not work because spell vs aura
+	[50461] = { type = "buffs_defensive", },  -- Anti-Magic Zone
 	[49028] = { type = "buffs_offensive", },  -- Dancing Rune Weapon // might not work - spell id vs aura
 	[49916] = { type = "cc", },  -- Strangulate
 	[47481] = { type = "cc", },  -- Gnaw

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -184,6 +184,7 @@ BigDebuffs.Spells = {
 	[51713] = { type = "buffs_offensive", }, -- Shadow Dance
 	[13750] = { type = "buffs_offensive", },  -- Adrenaline Rush
 	[51690] = { type = "buffs_offensive", },  -- Killing Spree
+	[14177] = { type = "buffs_offensive", }, -- Cold Blood
 	[11305] = { type = "buffs_other", },  -- Sprint
 	[26669] = { type = "buffs_defensive", },  -- Evasion
 	[1776] = { type = "cc", },  -- Gouge

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -463,7 +463,7 @@ function BigDebuffs:AttachUnitFrame(unit)
 			frame:SetParent(frame.anchor:GetParent())
 			frame:SetFrameLevel(frame.anchor:GetParent():GetFrameLevel())
 			frame.cooldownContainer:SetFrameLevel(frame.anchor:GetParent():GetFrameLevel()-1)
-			frame.cooldownContainer:SetSize(frame.anchor:GetWidth()-12, frame.anchor:GetHeight()-10)
+			frame.cooldownContainer:SetSize(frame.anchor:GetWidth()-8, frame.anchor:GetHeight()-8)
 			frame.anchor:SetDrawLayer("BACKGROUND")
 		else
 			frame:SetParent(frame.parent and frame.parent or frame.anchor)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -228,6 +228,7 @@ BigDebuffs.Spells = {
 	[1719] = { type = "buffs_offensive", },  -- Recklessness
 	[12292] = { type = "buffs_offensive", }, -- Death Wish
 	[18499] = { type = "buffs_other", },  -- Berserker Rage
+	[12809] = { type = "cc", }, -- Concussion Blow
 	[676] = { type = "cc", },  -- Disarm
 	[55918] = { type = "cc", },  -- Shockwave
 		[46968] = { type = "cc", },

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -1,5 +1,5 @@
 
--- BigDebuffs by Jordon (& improved / backported by Konjunktur)
+-- BigDebuffs by Jordon (& improved / backported by Konjunktur & Apparent)
 
 BigDebuffs = LibStub("AceAddon-3.0"):NewAddon("BigDebuffs", "AceEvent-3.0", "AceHook-3.0", "AceTimer-3.0")
 
@@ -63,144 +63,138 @@ local defaults = {
 }
 
 BigDebuffs.Spells = {
-
-	["Dispersion"] = { type = "buffs_defensive", },  -- Dispersion
-	["Frenzied Regeneration"] = { type = "buffs_defensive", },  -- Frenzied Regeneration
-	["Hand of Protection"] = { type = "buffs_defensive", },  -- Blessing of Protection
-	["Spirit of Redemption"] = { type = "buffs_defensive", },  -- Spirit of Redemption
-	["Survival Instincts"] = { type = "buffs_defensive", },  -- Survival Instincts
-	["Roar of Sacrifice"] = { type = "buffs_defensive", },  -- Roar of Sacrifice (Hunter Pet Skill)
-	["Deterrence"] = { type = "buffs_defensive", },  -- Deterrence
-	["Evasion"] = { type = "buffs_defensive", },  -- Evasion
-	["Ardent Defender"] = { type = "buffs_defensive", },  -- Ardent Defender
-	["Barkskin"] = { type = "buffs_defensive", },  -- Barkskin
-	["Fear Ward"] = { type = "buffs_defensive", },  -- Fear Ward
-	["Last Stand"] = { type = "buffs_defensive", },  -- Last Stand
-	["Inner Focus"] = { type = "buffs_defensive", },  -- Inner Focus
-	["Pain Suppression"] = { type = "buffs_defensive", },  -- Pain Suppression
-	["Aura Mastery"] = { type = "buffs_defensive", },  -- Aura Mastery
-	["Icebound Fortitude"] = { type = "buffs_defensive", },  -- Icebound Fortitude
-	["Guardian Spirit"] = { type = "buffs_defensive", },  -- Guardian Spirit
-	["Feint"] = { type = "buffs_defensive", },  -- Feint
-	["Enraged Regeneration"] = { type = "buffs_defensive", },  -- Enraged Regeneration
-	["Divine Hymn"] = { type = "buffs_defensive", },  -- Divine Hymn
-	["Unbreakable Armor"] = { type = "buffs_defensive", },  -- Unbreakable Armor
-	["Shield Wall"] = { type = "buffs_defensive", },  -- Shield Wall
-	["Ice Barrier"] = { type = "buffs_defensive", },  -- Ice Barrier
-	["Feign Death"] = { type = "buffs_defensive", },  -- Feign Death
-	["Tranquility"] = { type = "buffs_defensive", },  -- Tranquility
-	["Divine Illumination"] = { type = "buffs_defensive"},  -- Divine Illumination
-	["Divine Protection"] = { type = "buffs_defensive", },  -- Divine Protection
-	["Hand of Sacrifice"] = { type = "buffs_defensive", },  -- Blessing of Sacrifice
-	["Hand of Freedom"] = { type = "buffs_defensive", },  -- Blessing of Freedom
-	["Vampiric Blood"] = { type = "buffs_defensive", },  -- Vampiric Blood
-
-	["Master's Call"] = { type = "buffs_defensive", },  -- Master's Call
-	["Divine Favor"] = { type = "buffs_defensive", },  -- Divine Favor
-	["Anti-Magic Zone"] = { type = "buffs_defensive", },  -- Anti-Magic Zone
-	["Hysteria"] = { type = "buffs_defensive", },  -- Hysteria
-
-	["Innervate"] = { type = "buffs_offensive", },  -- Innervate
-	["Tiger's Fury"] = { type = "buffs_offensive", },  -- Tiger's Fury
-	["Dancing Rune Weapon"] = { type = "buffs_offensive", },  -- Dancing Rune Weapon
-	["Icy Veins"] = { type = "buffs_offensive", },  -- Icy Veins
-	["Tree of Life"] = { type = "buffs_offensive", },  -- Tree of Life
-	["Avenging Wrath"] = { type = "buffs_offensive", },  -- Avenging Wrath (Protection/Retribution)
-	["Adrenaline Rush"] = { type = "buffs_offensive", },  -- Adrenaline Rush
-	["Combustion"] = { type = "buffs_offensive", },  -- Combustion
-	["Arcane Power"] = { type = "buffs_offensive", },  -- Arcane Power
-	["Elemental Mastery"] = { type = "buffs_offensive", },  -- Elemental Mastery
-	["Berserk"] = { type = "buffs_offensive", },  -- Berserk
-	["Recklessness"] = { type = "buffs_offensive", },  -- Battle Cry
-	["Bloodlust"] = { type = "buffs_offensive", },  -- Bloodlust
-		["Heroism"] = { type = "buffs_offensive"},  -- Heroism
-	["Killing Spree"] = { type = "buffs_offensive", },  -- Killing Spree
-	["Power Infusion"] = { type = "buffs_offensive", },  -- Power Infusion
-	["Presence of Mind"] = { type = "buffs_offensive", },  -- Presence of Mind
-	["Evocation"] = { type = "buffs_offensive", },  -- Evocation
-	["Invisibility"] = { type = "buffs_offensive", },  -- Invisibility
-	["Bestial Wrath"] = { type = "buffs_offensive", },  -- Bestial Wrath
-
-	["Drink"] = { type = "buffs_other", },  -- Drink
-		["Refreshment"] = { type = "buffs_other"},  -- Refreshment
-	["Dash"] = { type = "buffs_other", },  -- Dash
-	["Sprint"] = { type = "buffs_other", },  -- Sprint
-	["Viper Sting"] = { type = "buffs_other", },  -- Viper Sting
-	["Fel Domination"] = { type = "buffs_other", },  -- Fel Domination
-	["Berserker Rage"] = { type = "buffs_other", },  -- Berserker Rage
-	["Hypothermia"] = { type = "buffs_other", },  -- Hypothermia
-
-	["Shadowfury"] = { type = "cc", },  -- Shadowfury
-	["Gouge"] = { type = "cc", },  -- Gouge
-	["Disarm"] = { type = "cc", },  -- Disarm
-	["Dismantle"] = {type = "cc", }, -- Dismantle
-	["Hex"] = { type = "cc", },  -- Hex
-	["Polymorph"] = { type = "cc", },  -- Polymorph
-	["Intimidation"] = { type = "cc", },  -- Intimidation
-	["Arcane Torrent"] = { type = "cc", },  -- Arcane Torrent
-	["Maim"] = { type = "cc" },  -- Maim
-	["Blind"] = { type = "cc", },  -- Blind
-	["Bash"] = { type = "cc", },  -- Bash
-	["Kidney Shot"] = { type = "cc", },  -- Kidney Shot
-	["Sap"] = { type = "cc", },  -- Sap
-	["Hibernate"] = {type = "cc"}, -- Hibernate
-	["Wyvern Sting"] = { type = "cc", },  -- Wyvern Sting
-	["Strangulate"] = { type = "cc", },  -- Strangulate 
-	["Garrote - Silence"] = { type = "cc", },  -- Garrote - Silence
-	["Unstable Affliction (Silence)"] = { type = "cc", },  -- Unstable Affliction (Silence)
-	["Silencing Shot"] = { type = "cc", },
-	["Repentance"] = { type = "cc", },  -- Repentance
-	["Shockwave"] = { type = "cc", },  -- Shockwave
-	["Kidney Shot"] = { type = "cc", },  -- Kidney Shot
-	["Gnaw"] = { type = "cc", },  -- Gnaw
-	["Psychic Scream"] = { type = "cc", },  -- Psychic Scream
-	["Scatter Shot"] = { type = "cc", },  -- Scatter Shot
-	["Banish"] = { type = "cc", },  -- Banish
-	["Freezing Trap Effect"] = { type = "cc", },  -- Freezing Trap
-	["Inferno Effect"] = { type = "cc", },  -- Infernal Awakening
-	["Silence"] = { type = "cc", },  -- Silence
-	["Death Coil"] = { type = "cc", },  -- Mortal Coil
-	["Hammer of Justice"] = { type = "cc", },  -- Hammer of Justice
-	["War Stomp"] = { type = "cc", },  -- War Stomp
-	["Intimidating Shout"] = { type = "cc", },  -- Intimidating Shout
-	["Mind Control"] = { type = "cc", },  -- Mind Control
-	["Seduction"] = { type = "cc", },  -- Seduction
-	["Fear"] = { type = "cc", },  -- Fear
-	["Howl of Terror"] = { type = "cc", },  -- Howl of Terror
-	["Cheap Shot"] = { type = "cc", },  -- Cheap Shot
-	["Pounce"] = { type = "cc", },  -- Pounce
-	["Avenger's Shield"] = { type = "cc", },  -- Avenger's Shield
-	["Cyclone"] = { type = "cc" },  -- Cyclone
-	["Dragon's Breath"] = { type = "cc", },  -- Dragon's Breath
-	["Shackle Undead"] = { type = "cc", },  -- Shackle Undead
-	["Charge"] = { type = "cc", }, -- Charge
-	["Intercept"] = { type = "cc", }, -- Intercept
-	["Hungering Cold"] = { type = "cc", }, -- Hungering Cold
-
-	["Ice Block"] = { type = "immunities", },  -- Ice Block
-	["Bladestorm"] = { type = "immunities", },  -- Bladestorm (Arms)
-	["Divine Shield"] = { type = "immunities", },  -- Divine Shield
-
-	["Spell Reflection"] = { type = "immunities_spells", },  -- Spell Reflection
-	["Anti-Magic Shell"] = { type = "immunities_spells", },  -- Anti-Magic Shell
-	["Cloak of Shadows"] = { type = "immunities_spells", },  -- Cloak of Shadows
-	["Lichborne"] = { type = "immunities_spells", },  -- Lichborne
-
+	[47585] = { type = "buffs_defensive", },  -- Dispersion
+	[22842] = { type = "buffs_defensive", },  -- Frenzied Regeneration
+	[10278] = { type = "buffs_defensive", },  -- Hand of Protection
+		[5599] = { type = "buffs_defensive", },
+		[1022] = { type = "buffs_defensive", },
+	[20711] = { type = "buffs_defensive", },  -- Spirit of Redemption
+	[61336] = { type = "buffs_defensive", },  -- Survival Instincts
+	[53480] = { type = "buffs_defensive", },  -- Roar of Sacrifice (Hunter Pet Skill)
+	[19263] = { type = "buffs_defensive", },  -- Deterrence
+	[26669] = { type = "buffs_defensive", },  -- Evasion
+	[31852] = { type = "buffs_defensive", },  -- Ardent Defender
+	[22812] = { type = "buffs_defensive", },  -- Barkskin
+	[6346] = { type = "buffs_defensive", },  -- Fear Ward
+	[12975] = { type = "buffs_defensive", },  -- Last Stand
+	[14751] = { type = "buffs_defensive", },  -- Inner Focus
+	[33206] = { type = "buffs_defensive", },  -- Pain Suppression
+	[31821] = { type = "buffs_defensive", },  -- Aura Mastery
+	[66023] = { type = "buffs_defensive", },  -- Icebound Fortitude
+	[47788] = { type = "buffs_defensive", },  -- Guardian Spirit
+	[55694] = { type = "buffs_defensive", },  -- Enraged Regeneration
+	[64843] = { type = "buffs_defensive", },  -- Divine Hymn
+	[871] = { type = "buffs_defensive", },  -- Shield Wall
+	[43039] = { type = "buffs_defensive", },  -- Ice Barrier
+	[5384] = { type = "buffs_defensive", },  -- Feign Death
+	[498] = { type = "buffs_defensive", },  -- Divine Protection
+	[6940] = { type = "buffs_defensive", },  -- Hand of Sacrifice
+	[1044] = { type = "buffs_defensive", },  -- Hand of Freedom
+	[53271] = { type = "buffs_defensive", },  -- Master's Call
+	[51052] = { type = "buffs_defensive", },  -- Anti-Magic Zone // might not work because spell vs aura
+	[29166] = { type = "buffs_offensive", },  -- Innervate
+	[50213] = { type = "buffs_offensive", },  -- Tiger's Fury
+	[49028] = { type = "buffs_offensive", },  -- Dancing Rune Weapon // might not work - spell id vs aura
+	[12472] = { type = "buffs_offensive", },  -- Icy Veins
+	[31884] = { type = "buffs_offensive", },  -- Avenging Wrath
+	[13750] = { type = "buffs_offensive", },  -- Adrenaline Rush
+	[28682] = { type = "buffs_offensive", },  -- Combustion
+	[12042] = { type = "buffs_offensive", },  -- Arcane Power
+	[64701] = { type = "buffs_offensive", },  -- Elemental Mastery
+	[50334] = { type = "buffs_offensive", },  -- Berserk
+	[1719] = { type = "buffs_offensive", },  -- Recklessness
+	[2825] = { type = "buffs_offensive", },  -- Bloodlust
+		[32182] = { type = "buffs_offensive"},  -- Heroism
+	[51690] = { type = "buffs_offensive", },  -- Killing Spree
+	[10060] = { type = "buffs_offensive", },  -- Power Infusion
+	[12043] = { type = "buffs_offensive", },  -- Presence of Mind
+	[12051] = { type = "buffs_offensive", },  -- Evocation
+	[66] = { type = "buffs_offensive", },  -- Invisibility
+	[34471] = { type = "buffs_offensive", },  -- The Beast Within
+	[57073] = { type = "buffs_other", },  -- Drink
+	[33357] = { type = "buffs_other", },  -- Dash
+	[11305] = { type = "buffs_other", },  -- Sprint
+	[3034] = { type = "buffs_other", },  -- Viper Sting
+	[18708] = { type = "buffs_other", },  -- Fel Domination
+	[18499] = { type = "buffs_other", },  -- Berserker Rage
+	[47847] = { type = "cc", },  -- Shadowfury
+	[1776] = { type = "cc", },  -- Gouge
+	[676] = { type = "cc", },  -- Disarm
+	[51722] = {type = "cc", }, -- Dismantle
+	[51514] = { type = "cc", },  -- Hex
+	[118] = { type = "cc", },  -- Polymorph
+		[12826] = { type = "cc", },
+		[71319] = { type = "cc", },
+		[28271] = { type = "cc", },
+		[28272] = { type = "cc", },
+		[61305] = { type = "cc", },
+		[61721] = { type = "cc", },
+	[24394] = { type = "cc", },  -- Intimidation
+		[19577] = { type = "cc", },
+	[49802] = { type = "cc" },  -- Maim
+	[2094] = { type = "cc", },  -- Blind
+	[8983] = { type = "cc", },  -- Bash
+	[8643] = { type = "cc", },  -- Kidney Shot
+	[51724] = { type = "cc", },  -- Sap
+	[18658] = {type = "cc"}, -- Hibernate
+		[2637] = {type = "cc"},
+		[18657] = {type = "cc"},
+	[49012] = { type = "cc", },  -- Wyvern Sting
+	[49916] = { type = "cc", },  -- Strangulate 
+	[1330] = { type = "cc", },  -- Garrote - Silence
+	[31117] = { type = "cc", },  -- Unstable Affliction (Silence)
+	[34490] = { type = "cc", },
+	[20066] = { type = "cc", },  -- Repentance
+	[55918] = { type = "cc", },  -- Shockwave
+		[46968] = { type = "cc", },
+	[47481] = { type = "cc", },  -- Gnaw
+	[27610] = { type = "cc", },  -- Psychic Scream
+		[10890] = { type = "cc", },
+	[19503] = { type = "cc", },  -- Scatter Shot
+	[18647] = { type = "cc", },  -- Banish
+	[14309] = { type = "cc", },  -- Freezing Trap
+	[15487] = { type = "cc", },  -- Silence
+	[47860] = { type = "cc", },  -- Death Coil
+	[10308] = { type = "cc", },  -- Hammer of Justice
+	[20549] = { type = "cc", },  -- War Stomp
+	[5246] = { type = "cc", },  -- Intimidating Shout
+	[605] = { type = "cc", },  -- Mind Control
+	[6358] = { type = "cc", },  -- Seduction
+	[6215] = { type = "cc", },  -- Fear
+	[17928] = { type = "cc", },  -- Howl of Terror
+	[1833] = { type = "cc", },  -- Cheap Shot
+	[49803] = { type = "cc", },  -- Pounce
+	[33786] = { type = "cc" },  -- Cyclone
+	[69369] = { type = "buffs_offensive", }, -- Predator's Swiftness ---- problem here
+	[42950] = { type = "cc", },  -- Dragon's Breath
+	[10955] = { type = "cc", },  -- Shackle Undead
+	[7922] = { type = "cc", }, -- Charge
+		[65929] = { type = "cc", },
+	[25274] = { type = "cc", }, -- Intercept
+	[49203] = { type = "cc", }, -- Hungering Cold
+	[45438] = { type = "immunities", },  -- Ice Block
+	[65947] = { type = "immunities", },  -- Bladestorm
+		[63784] = { type = "immunities", },
+		[46924] = { type = "immunities", },
+	[63148] = { type = "immunities", },  -- Divine Shield
+	[23920] = { type = "immunities_spells", },  -- Spell Reflection
+		[59725] = { type = "immunities_spells", },
+	[48707] = { type = "immunities_spells", },  -- Anti-Magic Shell
+	[31224] = { type = "immunities_spells", },  -- Cloak of Shadows
+	[49039] = { type = "immunities_spells", },  -- Lichborne
+	[45334] = { type = "roots", },  -- Feral Charge Effect
+	[12494] = { type = "roots", },  -- Frostbite
+	[42917] = { type = "roots", },  -- Frost Nova
+	[44572] = { type = "cc" }, -- Deep Freeze
+	[53308] = { type = "roots", },  -- Entangling Roots
+	[8178] = { type = "immunities_spells", }, -- Grounding Totem Effect
 	["Pummel"] = { type = "interrupts", interruptduration = 4, },  -- Pummel (Warrior)
 	["Counterspell"] = { type = "interrupts", interruptduration = 6, },  -- Counterspell (Mage)
 	["Spell Lock"] = { type = "interrupts", interruptduration = 5, },  -- Spell Lock (Warlock)
 	["Mind Freeze"] = { type = "interrupts", interruptduration = 3, },  -- Mind Freeze (Death Knight)
-	["Feral Charge - Bear"] = { type = "interrupts", interruptduration = 4, },  -- Feral Charge - Bear
+	["Feral Charge - Bear"] = { type = "interrupts", interruptduration = 4, },  -- Feral Charge - Bear (Druid)
 	["Wind Shear"] = { type = "interrupts", interruptduration = 3, },  -- Wind Shear (Shaman)
 	["Kick"] = { type = "interrupts", interruptduration = 5, },  -- Kick (Rogue)
-
-	["Feral Charge Effect"] = { type = "roots", },  -- Wild Charge
-	["Frostbite"] = { type = "roots", },  -- Frostbite
-	["Frost Nova"] = { type = "roots", },  -- Frost Nova
-		["Freeze"] = { type = "roots", },  -- Freeze
-	["Earthgrab"] = { type = "roots", },  -- Earthgrab Totem
-	["Entangling Roots"] = { type = "roots", },  -- Entangling Roots
-	["Nature's Grasp"] = { type = "roots", }, -- Nature's Grasp
 }
 
 local units = {

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -138,6 +138,7 @@ BigDebuffs.Spells = {
 	[498] = { type = "buffs_defensive", },  -- Divine Protection
 	[6940] = { type = "buffs_defensive", },  -- Hand of Sacrifice
 	[1044] = { type = "buffs_defensive", },  -- Hand of Freedom
+	[64205] = { type = "buffs_defensive", }, -- Divine Sacrifice
 	[31884] = { type = "buffs_offensive", },  -- Avenging Wrath
 	[20066] = { type = "cc", },  -- Repentance
 	[10308] = { type = "cc", },  -- Hammer of Justice

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -113,6 +113,7 @@ BigDebuffs.Spells = {
 	[53543] = { type = "cc", }, -- Snatch (Pet Disarm)
 	[53548] = { type = "roots", }, -- Pin (Pet)
 	[4167] = { type = "roots", }, -- Web (Pet)
+	[26090] = { type = "interrupts", interruptduration = 2, }, -- Pummel (Pet)
 	-- Mage
 	[43039] = { type = "buffs_defensive", },  -- Ice Barrier
 	[12472] = { type = "buffs_offensive", },  -- Icy Veins

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -169,9 +169,13 @@ BigDebuffs.Spells = {
 	-- Shaman
 	[64701] = { type = "buffs_offensive", },  -- Elemental Mastery
 	[2825] = { type = "buffs_offensive", },  -- Bloodlust
-	[32182] = { type = "buffs_offensive"},  -- Heroism
+	[32182] = { type = "buffs_offensive", },  -- Heroism
+	[16191] = { type = "buffs_offensive", }, -- Mana Tide Totem
+	[30823] = { type = "buffs_defensive", }, -- Shamanistic Rage
 	[51514] = { type = "cc", },  -- Hex
 	[8178] = { type = "immunities_spells", }, -- Grounding Totem Effect
+	[63685] = { type = "roots", }, -- Freeze (Enhancement)
+	[8145] = { type = "buffs_other", }, -- Tremor Totem
 	["Wind Shear"] = { type = "interrupts", interruptduration = 3, },  -- Wind Shear (Shaman)
 	-- Warlock
 	[18708] = { type = "buffs_other", },  -- Fel Domination

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -99,6 +99,7 @@ BigDebuffs.Spells = {
 	[33786] = { type = "immunities" },  -- Cyclone
 	[45334] = { type = "roots", },  -- Feral Charge Effect (Immobilize)
 	[53308] = { type = "roots", },  -- Entangling Roots
+	[53313] = { type = "roots", }, -- Entangling Roots (From Nature's Grasp)
 	[19675] = { type = "interrupts", interruptduration = 4, },  -- Feral Charge Effect (Interrupt)
 	-- Hunter
 	[3045] = { type = "buffs_offensive", }, -- Rapid Fire
@@ -557,20 +558,6 @@ function BigDebuffs:OnEnable()
 	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
 	self:RegisterEvent("UNIT_SPELLCAST_FAILED")
 	self.interrupts = {}
-	self.lastKnownStance = {
-		player = nil,
-		target = nil,
-		focus = nil,
-		party1 = nil,
-		party2 = nil,
-		party3 = nil,
-		party4 = nil,
-		arena1 = nil,
-		arena2 = nil,
-		arena3 = nil,
-		arena4 = nil,
-		arena5 = nil,
-	}
 
 	-- Prevent OmniCC finish animations
 	if OmniCC then
@@ -588,6 +575,22 @@ function BigDebuffs:PLAYER_ENTERING_WORLD()
 	for i = 1, #units do
 		self:AttachUnitFrame(units[i])
 	end
+
+	self.lastKnownStance = {
+		player = nil,
+		target = nil,
+		focus = nil,
+		party1 = nil,
+		party2 = nil,
+		party3 = nil,
+		party4 = nil,
+		arena1 = nil,
+		arena2 = nil,
+		arena3 = nil,
+		arena4 = nil,
+		arena5 = nil,
+	}
+
 end
 
 -- For unit frames

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -68,7 +68,7 @@ BigDebuffs.Spells = {
 	[50461] = { type = "buffs_defensive", },  -- Anti-Magic Zone
 	[47484] = { type = "buffs_defensive", }, -- Huddle (Ghoul)
 	[49028] = { type = "buffs_offensive", },  -- Dancing Rune Weapon // might not work - spell id vs aura
-	[49916] = { type = "cc", },  -- Strangulate
+	[47476] = { type = "cc", },  -- Strangulate
 	[47481] = { type = "cc", },  -- Gnaw
 	[49203] = { type = "cc", }, -- Hungering Cold
 	[48707] = { type = "immunities_spells", },  -- Anti-Magic Shell

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -85,6 +85,11 @@ BigDebuffs.Spells = {
 	[53201] = { type = "buffs_offensive", }, -- Starfall
 	[53312] = { type = "buffs_other", }, -- Nature's Grasp
 	[33357] = { type = "buffs_other", },  -- Dash
+	[768] = { type = "buffs_other", }, -- Cat Form
+	[9634] = { type = "buffs_other", }, -- Dire Bear Form
+	[783] = { type = "buffs_other", }, -- Travel Form
+	[24858] = { type = "buffs_other", }, -- Moonkin Form
+	[33891] = { type = "buffs_other", }, -- Tree of Life
 	[49802] = { type = "cc" },  -- Maim
 	[8983] = { type = "cc", },  -- Bash
 	[18658] = {type = "cc"}, -- Hibernate
@@ -473,7 +478,7 @@ function BigDebuffs:AttachUnitFrame(unit)
 			frame:SetParent(frame.anchor:GetParent())
 			frame:SetFrameLevel(frame.anchor:GetParent():GetFrameLevel())
 			frame.cooldownContainer:SetFrameLevel(frame.anchor:GetParent():GetFrameLevel()-1)
-			frame.cooldownContainer:SetSize(frame.anchor:GetWidth()-8, frame.anchor:GetHeight()-8)
+			frame.cooldownContainer:SetSize(frame.anchor:GetWidth()-9, frame.anchor:GetHeight()-8)
 			frame.anchor:SetDrawLayer("BACKGROUND")
 		else
 			frame:SetParent(frame.parent and frame.parent or frame.anchor)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -162,6 +162,7 @@ BigDebuffs.Spells = {
 	[14751] = { type = "buffs_defensive", },  -- Inner Focus
 	[33206] = { type = "buffs_defensive", },  -- Pain Suppression
 	[64843] = { type = "buffs_defensive", },  -- Divine Hymn
+	[64901] = { type = "buffs_defensive", }, -- Hymn of Hope
 	[10060] = { type = "buffs_offensive", },  -- Power Infusion
 	[6346] = { type = "buffs_other", },  -- Fear Ward
 	[27610] = { type = "cc", },  -- Psychic Scream

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -178,6 +178,7 @@ BigDebuffs.Spells = {
 	[16191] = { type = "buffs_offensive", }, -- Mana Tide Totem
 	[30823] = { type = "buffs_defensive", }, -- Shamanistic Rage
 	[51514] = { type = "cc", },  -- Hex
+	[39796] = { type = "cc", }, -- Stoneclaw Stun
 	[8178] = { type = "immunities_spells", }, -- Grounding Totem Effect
 	[63685] = { type = "roots", }, -- Freeze (Enhancement)
 	[64695] = { type = "roots", }, -- Earthgrab (Elemental)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -103,6 +103,7 @@ BigDebuffs.Spells = {
 	[49012] = { type = "cc", },  -- Wyvern Sting
 	[19503] = { type = "cc", },  -- Scatter Shot
 	[14309] = { type = "cc", },  -- Freezing Trap
+	[60210] = { type = "cc", }, -- Freezing Arrow Effect
 	-- Mage
 	[43039] = { type = "buffs_defensive", },  -- Ice Barrier
 	[12472] = { type = "buffs_offensive", },  -- Icy Veins

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -128,7 +128,7 @@ BigDebuffs.Spells = {
 	-- Mage
 	[43039] = { type = "buffs_other", },  -- Ice Barrier
 	[12472] = { type = "buffs_offensive", },  -- Icy Veins
-	[28682] = { type = "buffs_offensive", },  -- Combustion
+	[54748] = { type = "buffs_offensive", }, -- Burning Determination (Interrupt/Silence Immunity)
 	[12042] = { type = "buffs_offensive", },  -- Arcane Power
 	[12043] = { type = "buffs_offensive", },  -- Presence of Mind
 	[12051] = { type = "buffs_offensive", },  -- Evocation

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -258,7 +258,7 @@ BigDebuffs.Spells = {
 	[46924] = { type = "immunities", },  -- Bladestorm
 	[23920] = { type = "immunities_spells", },  -- Spell Reflection
 	[6552] = { type = "interrupts", interruptduration = 4, },  -- Pummel
-	[72] = { type = "interrupts", interruptduration = 6, }, -- Shield Bash
+	[72] = { type = "interrupts", interruptduration = 5, }, -- Shield Bash
 	-- Misc
 	[43183] = { type = "buffs_other", },  -- Drink (Arena/Lvl 80 Water)
 		[57073] = { type = "buffs_other" }, -- (Mage Water)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -217,6 +217,7 @@ BigDebuffs.Spells = {
 	[63685] = { type = "roots", }, -- Freeze (Enhancement)
 	[64695] = { type = "roots", }, -- Earthgrab (Elemental)
 	[58875] = { type = "buffs_other", }, -- Spirit Walk (Spirit Wolf)
+	[55277] = { type = "buffs_other", }, -- Stoneclaw Totem (Absorb)
 	[57994] = { type = "interrupts", interruptduration = 2, },  -- Wind Shear
 	-- Warlock
 	[47241] = { type = "buffs_offensive", }, -- Metamorphosis

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -123,7 +123,8 @@ BigDebuffs.Spells = {
 		[61305] = { type = "cc", },
 		[61721] = { type = "cc", },
 	[42950] = { type = "cc", },  -- Dragon's Breath
-	[44572] = { type = "cc" }, -- Deep Freeze
+	[44572] = { type = "cc", }, -- Deep Freeze
+	[64343] = { type = "cc", }, -- Impact
 	[45438] = { type = "immunities", },  -- Ice Block
 	[12494] = { type = "roots", },  -- Frostbite
 	[42917] = { type = "roots", },  -- Frost Nova

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -73,7 +73,7 @@ BigDebuffs.Spells = {
 	[49203] = { type = "cc", }, -- Hungering Cold
 	[48707] = { type = "immunities_spells", },  -- Anti-Magic Shell
 	[49039] = { type = "immunities_spells", },  -- Lichborne
-	["Mind Freeze"] = { type = "interrupts", interruptduration = 3, },  -- Mind Freeze (Death Knight)
+	[53550] = { type = "interrupts", interruptduration = 4, },  -- Mind Freeze
 	-- Druid
 	[22842] = { type = "buffs_defensive", },  -- Frenzied Regeneration
 	[17116] = { type = "buffs_defensive", }, -- Nature's Swiftness
@@ -91,9 +91,9 @@ BigDebuffs.Spells = {
 		[18657] = {type = "cc"},
 	[49803] = { type = "cc", },  -- Pounce
 	[33786] = { type = "immunities" },  -- Cyclone
-	[45334] = { type = "roots", },  -- Feral Charge Effect
+	[45334] = { type = "roots", },  -- Feral Charge Effect (Immobilize)
 	[53308] = { type = "roots", },  -- Entangling Roots
-	["Feral Charge - Bear"] = { type = "interrupts", interruptduration = 4, },  -- Feral Charge - Bear (Druid)
+	[19675] = { type = "interrupts", interruptduration = 4, },  -- Feral Charge Effect (Interrupt)
 	-- Hunter
 	[3045] = { type = "buffs_offensive", }, -- Rapid Fire
 	[53480] = { type = "buffs_defensive", },  -- Roar of Sacrifice (Hunter Pet Skill)
@@ -199,7 +199,7 @@ BigDebuffs.Spells = {
 	[1833] = { type = "cc", },  -- Cheap Shot
 	[18425] = { type = "cc", }, -- Silence (Improved Kick)
 	[31224] = { type = "immunities_spells", },  -- Cloak of Shadows
-	["Kick"] = { type = "interrupts", interruptduration = 5, },  -- Kick (Rogue)
+	[1766] = { type = "interrupts", interruptduration = 5, },  -- Kick
 	-- Shaman
 	[64701] = { type = "buffs_offensive", },  -- Elemental Mastery
 	[2825] = { type = "buffs_offensive", },  -- Bloodlust
@@ -213,7 +213,7 @@ BigDebuffs.Spells = {
 	[63685] = { type = "roots", }, -- Freeze (Enhancement)
 	[64695] = { type = "roots", }, -- Earthgrab (Elemental)
 	[8145] = { type = "buffs_other", }, -- Tremor Totem
-	["Wind Shear"] = { type = "interrupts", interruptduration = 2, },  -- Wind Shear (Shaman)
+	[57994] = { type = "interrupts", interruptduration = 2, },  -- Wind Shear
 	-- Warlock
 	[47241] = { type = "buffs_offensive", }, -- Metamorphosis
 	[18708] = { type = "buffs_other", },  -- Fel Domination

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -139,6 +139,7 @@ BigDebuffs.Spells = {
 	[31884] = { type = "buffs_offensive", },  -- Avenging Wrath
 	[20066] = { type = "cc", },  -- Repentance
 	[10308] = { type = "cc", },  -- Hammer of Justice
+	[63529] = { type = "cc", }, -- Silenced - Shield of the Templar
 	[63148] = { type = "immunities", },  -- Divine Shield
 	-- Priest
 	[47585] = { type = "buffs_defensive", },  -- Dispersion

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -221,6 +221,7 @@ BigDebuffs.Spells = {
 	[871] = { type = "buffs_defensive", },  -- Shield Wall
 	[3411] = { type = "buffs_defensive", },  -- Intervene
 	[2565] = { type = "buffs_defensive", }, -- Shield Block
+	[20230] = { type = "buffs_defensive", }, -- Retaliation
 	[1719] = { type = "buffs_offensive", },  -- Recklessness
 	[18499] = { type = "buffs_other", },  -- Berserker Rage
 	[676] = { type = "cc", },  -- Disarm

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -199,6 +199,7 @@ BigDebuffs.Spells = {
 	[8145] = { type = "buffs_other", }, -- Tremor Totem
 	["Wind Shear"] = { type = "interrupts", interruptduration = 2, },  -- Wind Shear (Shaman)
 	-- Warlock
+	[47241] = { type = "buffs_offensive", }, -- Metamorphosis
 	[18708] = { type = "buffs_other", },  -- Fel Domination
 	[47847] = { type = "cc", },  -- Shadowfury
 	[31117] = { type = "cc", },  -- Unstable Affliction (Silence)

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -225,6 +225,7 @@ BigDebuffs.Spells = {
 	[47986] = { type = "buffs_other", }, -- Sacrifice
 	[60995] = { type = "cc", }, -- Demon Charge (Metamorphosis)
 	[47847] = { type = "cc", },  -- Shadowfury
+		[30283] = { type = "cc", },
 	[31117] = { type = "cc", },  -- Unstable Affliction (Silence)
 	[18647] = { type = "cc", },  -- Banish
 	[47860] = { type = "cc", },  -- Death Coil

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -107,6 +107,7 @@ BigDebuffs.Spells = {
 	[14309] = { type = "cc", },  -- Freezing Trap
 	[60210] = { type = "cc", }, -- Freezing Arrow Effect
 	[53562] = { type = "cc", }, -- Ravage (Pet)
+	[53543] = { type = "cc", }, -- Snatch (Pet Disarm)
 	[53548] = { type = "roots", }, -- Pin (Pet)
 	-- Mage
 	[43039] = { type = "buffs_defensive", },  -- Ice Barrier

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -426,7 +426,7 @@ function BigDebuffs:AttachUnitFrame(unit)
 			frame:SetParent(frame.anchor:GetParent())
 			frame:SetFrameLevel(frame.anchor:GetParent():GetFrameLevel())
 			frame.cooldownContainer:SetFrameLevel(frame.anchor:GetParent():GetFrameLevel()-1)
-			frame.cooldownContainer:SetSize(frame.anchor:GetWidth()-10, frame.anchor:GetHeight()-8)
+			frame.cooldownContainer:SetSize(frame.anchor:GetWidth()-12, frame.anchor:GetHeight()-10)
 			frame.anchor:SetDrawLayer("BACKGROUND")
 		else
 			frame:SetParent(frame.parent and frame.parent or frame.anchor)
@@ -719,8 +719,6 @@ function BigDebuffs:UNIT_AURA(event, unit)
 	end
 	
 	if debuff then
-		if duration < 1 then duration = 1 end -- auras like Solar Beam don't have a duration
-
 		if frame.current ~= icon then
 			if frame.blizzard then
 				-- Blizzard Frame
@@ -734,10 +732,12 @@ function BigDebuffs:UNIT_AURA(event, unit)
 			end
 		end
 		
-		frame.cooldown:SetCooldown(expires - duration, duration)
-		frame.cooldownContainer:Show()
-		frame:Show()
+		if duration > 1 then
+			frame.cooldown:SetCooldown(expires - duration, duration)
+			frame.cooldownContainer:Show()
+		end
 
+		frame:Show()
 		frame.current = icon
 	else
 		-- Adapt

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -141,6 +141,7 @@ BigDebuffs.Spells = {
 	[44572] = { type = "cc", }, -- Deep Freeze
 	[12355] = { type = "cc", }, -- Impact
 	[55021] = { type = "cc", }, -- Improved Counterspell
+	[64346] = { type = "cc", }, -- Fiery Payback (Fire Mage Disarm)
 	[45438] = { type = "immunities", },  -- Ice Block
 	[12494] = { type = "roots", },  -- Frostbite
 	[42917] = { type = "roots", },  -- Frost Nova

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -66,6 +66,7 @@ BigDebuffs.Spells = {
 	-- Death Knight
 	[48792] = { type = "buffs_defensive", },  -- Icebound Fortitude
 	[50461] = { type = "buffs_defensive", },  -- Anti-Magic Zone
+	[47484] = { type = "buffs_defensive", }, -- Huddle (Ghoul)
 	[49028] = { type = "buffs_offensive", },  -- Dancing Rune Weapon // might not work - spell id vs aura
 	[49916] = { type = "cc", },  -- Strangulate
 	[47481] = { type = "cc", },  -- Gnaw

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -200,7 +200,8 @@ BigDebuffs.Spells = {
 	[6358] = { type = "cc", },  -- Seduction
 	[6215] = { type = "cc", },  -- Fear
 	[17928] = { type = "cc", },  -- Howl of Terror
-	["Spell Lock"] = { type = "interrupts", interruptduration = 5, },  -- Spell Lock (Warlock)
+	[24259] = { type = "cc", }, -- Spell Lock (Silence)
+	[19647] = { type = "interrupts", interruptduration = 6, },  -- Spell Lock (Interrupt)
 	-- Warrior
 	[12975] = { type = "buffs_defensive", },  -- Last Stand
 	[55694] = { type = "buffs_defensive", },  -- Enraged Regeneration

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -174,6 +174,7 @@ BigDebuffs.Spells = {
 	[51724] = { type = "cc", },  -- Sap
 	[1330] = { type = "cc", },  -- Garrote - Silence
 	[1833] = { type = "cc", },  -- Cheap Shot
+	[18425] = { type = "cc", }, -- Silence (Improved Kick)
 	[31224] = { type = "immunities_spells", },  -- Cloak of Shadows
 	["Kick"] = { type = "interrupts", interruptduration = 5, },  -- Kick (Rogue)
 	-- Shaman

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -96,6 +96,7 @@ BigDebuffs.Spells = {
 	[19263] = { type = "buffs_defensive", },  -- Deterrence
 	[5384] = { type = "buffs_defensive", },  -- Feign Death
 	[53271] = { type = "buffs_defensive", },  -- Master's Call
+	[53476] = { type = "buffs_defensive", }, -- Intervene (Pet)
 	[34471] = { type = "buffs_offensive", },  -- The Beast Within
 	[3034] = { type = "buffs_other", },  -- Viper Sting
 	[24394] = { type = "cc", },  -- Intimidation
@@ -197,7 +198,7 @@ BigDebuffs.Spells = {
 	[12975] = { type = "buffs_defensive", },  -- Last Stand
 	[55694] = { type = "buffs_defensive", },  -- Enraged Regeneration
 	[871] = { type = "buffs_defensive", },  -- Shield Wall
-	[3411] = { type = "buffs_offensive", },  -- Intervene
+	[3411] = { type = "buffs_defensive", },  -- Intervene
 	[1719] = { type = "buffs_offensive", },  -- Recklessness
 	[18499] = { type = "buffs_other", },  -- Berserker Rage
 	[676] = { type = "cc", },  -- Disarm
@@ -505,10 +506,7 @@ function BigDebuffs:OnEnable()
 		end, true)
 	end
 
-	self:InsertTestDebuff(8122) 	-- Psychic Scream
-	self:InsertTestDebuff(408) 		-- Kidney Shot
-	self:InsertTestDebuff(30108) 	-- Unstable Affliction
-	self:InsertTestDebuff(339) 		-- Entangling Roots
+	self:InsertTestDebuff(69369) 	-- Predator's Swiftness
 end
 
 function BigDebuffs:PLAYER_ENTERING_WORLD()

--- a/BigDebuffs.lua
+++ b/BigDebuffs.lua
@@ -132,6 +132,7 @@ BigDebuffs.Spells = {
 	[12042] = { type = "buffs_offensive", },  -- Arcane Power
 	[12043] = { type = "buffs_offensive", },  -- Presence of Mind
 	[12051] = { type = "buffs_offensive", },  -- Evocation
+	[44544] = { type = "buffs_offensive", }, -- Fingers of Frost
 	[66] = { type = "buffs_offensive", },  -- Invisibility
 	[118] = { type = "cc", },  -- Polymorph
 		[12826] = { type = "cc", },

--- a/BigDebuffs.toc
+++ b/BigDebuffs.toc
@@ -2,7 +2,7 @@
 ## Title: BigDebuffs
 ## Notes: Increases the debuff size of crowd control effects on the Blizzard raid frames
 ## Version: v6.4
-## Author: Jordon (improved by Konjunktur)
+## Author: Jordon (WoTLK backport by Konjunktur & Apparent)
 ## DefaultState: Enabled
 ## SavedVariables: BigDebuffsDB
 ## OptionalDeps: LibStub, CallbackHandler-1.0, Ace3, Adapt, OmniCC, ButtonFacade

--- a/BigDebuffs.toc
+++ b/BigDebuffs.toc
@@ -2,7 +2,7 @@
 ## Title: BigDebuffs
 ## Notes: Increases the debuff size of crowd control effects on the Blizzard raid frames
 ## Version: v6.4
-## Author: Jordon (WoTLK backport by Konjunktur & Apparent)
+## Author: Jordon (WoTLK backport by Konjunktur)
 ## DefaultState: Enabled
 ## SavedVariables: BigDebuffsDB
 ## OptionalDeps: LibStub, CallbackHandler-1.0, Ace3, Adapt, OmniCC, ButtonFacade

--- a/Options.lua
+++ b/Options.lua
@@ -131,7 +131,7 @@ function BigDebuffs:SetupOptions()
 			desc = {
 				order = 2,
 				type = "description",
-				name = "|cffffd700 "..L["Author"].."|r Jordon (improved by Konjunktur) \n",
+				name = "|cffffd700 "..L["Author"].."|r Jordon (WoTLK backport by Konjunktur & Apparent) \n",
 				cmdHidden = true
 			},
 			test = {

--- a/Options.lua
+++ b/Options.lua
@@ -131,7 +131,7 @@ function BigDebuffs:SetupOptions()
 			desc = {
 				order = 2,
 				type = "description",
-				name = "|cffffd700 "..L["Author"].."|r Jordon (WoTLK backport by Konjunktur & Apparent) \n",
+				name = "|cffffd700 "..L["Author"].."|r Jordon (WoTLK backport by Konjunktur) \n",
 				cmdHidden = true
 			},
 			test = {

--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ To download this addon, hit the **green "Code" button** and then select `Downloa
 
 Once the addon is finished downloading, extract the contents to your `Interface/AddOns` directory and **importantly** rename the folder from `BigDebuffs-WoTLK-master` to `BigDebuffs`.
 
+---
+
 >**Backport Notes:**
-> The backport does not contain any raid frame modifications (number of debuffs shown / crowd control effects) since the
+> The backport is based on BfA BigDebuffs. However, the backport does not contain any raid frame 
+> modifications (number of debuffs shown / crowd control effects) since the
 > new raid frames do not exist in WotLK (they were implemented in Cataclysm).
 > The backport is essentially a much improved version of LoseControl.
 
----
+ I'd like to thank the following people for their contributions to this release:
+> [jordon][1] for the base addon, as developed throughout MoP-BfA (and possibly further)
+> [jakeswork][2] for his completion of the WotLK aura list, minor bug fixes and the Warrior stance logic addition.
 
-> **Developer's Note:** I'd like to thank the following people for their contributions to this release:
->  [NorkTheOrc][1] for his meticulous overhaul of the spell list. Most of the additions and fixes in this release were sent in by him.
->  [Pride][2] for his help updating the spell list.
->  [Jax][3] for his awesome concept of showing interrupts as a debuff, which I've fully integrated into this release.
 
-[1]: https://mods.curse.com/members/NorktheOrc/projects
-[2]: https://www.twitch.tv/pride_rag
-[3]: https://www.twitch.tv/jaxington
+[1]: https://github.com/jordonwow
+[2]: https://github.com/jakeswork

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ BigDebuffs is an _extremely lightweight_ addon that hooks the Blizzard raid fram
 
 The addon menu can be accessed by typing /bd or /bigdebuffs.
 
+### Downloading
+
+To download this addon, hit the **green "Code" button** and then select `Download ZIP`.
+
+Once the addon is finished downloading, extract the contents to your `Interface/AddOns` directory and **importantly** rename the folder from `BigDebuffs-WoTLK-master` to `BigDebuffs`.
+
 >**Backport Notes:**
 > The backport does not contain any raid frame modifications (number of debuffs shown / crowd control effects) since the
 > new raid frames do not exist in WotLK (they were implemented in Cataclysm).


### PR DESCRIPTION
Great work on this. I've made some changes to the base repo over my time using it and thought I'd share.

The major difference is opting to use spell ids rather than spell names. When using the strings, it just wasn't working consistently (only half of the spells would show). Swapping to IDs seems to have fixed this

This PR also includes
- A more comprehensive spell list - some stuff was missing that wotlk players would be interested in seeing
- A better solution to displaying icons that don't have durations. Previously it would show the cooldown overlay and made the icon just look dark - the solution I opted for was to only render the cooldown overlay should there be a cooldown to show
- _minor_: separated spells into classes, makes it easier to navigate/spot missing important spells

I'd recommend pulling down the original and my fork and playing around with it to really see the benefits.

I plan on adding more to this also - this PR is so that (should you want my updates) the changes aren't as drastic in future PRs.